### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ doesn't. This means that you won't be told what PIN code to enter.
 To get around this, run the following in a separate console before you start
 pairing:
 
-    hcidump -at | grep -i passkey -A1
+    sudo hcidump -at | grep -i passkey -A1
 
 During the pairing process, you are looking out for lines like:
 


### PR DESCRIPTION
Passkey sniffing works for superuser only. To avoid confusion suggest using sudo with hcidump.

I bumped into this couple times and ended up using "bluez-test-*" way of pairing.

I'm running on Ubuntu 12.04.