### PR TITLE
fix: improve Fn-Lock disabling rule for Keyboard II BT

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ If so create a udev rule with the following command:
     #ThinkPad TrackPoint Keyboard I & II Bluetooth
     SUBSYSTEM=="input", \
     ATTRS{id/vendor}=="17ef", ATTRS{id/product}=="6048|60e1", \
-    TEST=="/sys/$devpath/device/fn_lock", \
-    RUN+="/bin/sh -c 'echo 0 > \"/sys/$devpath/device/fn_lock\"'"
+    RUN+="/bin/sh -c 'sleep 0.1; FILE=\"/sys/$devpath/device/fn_lock\"; [ -e \"$FILE\" ] && echo 0 > \"$FILE\"'"
     EOF
 
     #Run commands to reload udev


### PR DESCRIPTION
The udev rule for disabling the Fn-Lock key stopped working.

I'd been using the rule described in the README successfully for months but a few days ago I noticed that it no longer works, i.e. the Fn-Lock key gets enabled when I connect the keyboard via Bluetooth.

The rule only works when i connect the keyboard for the first time after system reboot, but fails on every subsequent connection.

It seems that the event fires before the file `/sys/$devpath/device/fn_lock` is created. 

Adding a small delay fixes the issue.

Device: ThinkPad TrackPoint Keyboard II
Connection: Bluetooth 
OS: Ubuntu 22.04